### PR TITLE
Remove unnecessary 'as' properties

### DIFF
--- a/components/ArticleItem.js
+++ b/components/ArticleItem.js
@@ -3,7 +3,7 @@ import articleStyles from '../styles/Article.module.css'
 
 const ArticleItem = ({ article }) => {
   return (
-    <Link href='/article/[id]' as={`/article/${article.id}`}>
+    <Link href='/article/[id]'>
       <a className={articleStyles.card}>
         <h3>{article.title} &rarr;</h3>
         <p>{article.excerpt}</p>

--- a/components/ArticleItem.js
+++ b/components/ArticleItem.js
@@ -3,7 +3,7 @@ import articleStyles from '../styles/Article.module.css'
 
 const ArticleItem = ({ article }) => {
   return (
-    <Link href='/article/[id]'>
+    <Link href={`/article/${article.id}`}>
       <a className={articleStyles.card}>
         <h3>{article.title} &rarr;</h3>
         <p>{article.excerpt}</p>


### PR DESCRIPTION
Hi dear Brad Traversy,

As it is explained in official Next.js documentation, in latest versions of Next.js, using 'as' property is optional and we can simply use it's value for 'href' property. More info could be found here : https://nextjs.org/blog/next-10#automatic-resolving-of-href

I'd be grateful if you consider my pull request as a useful one.